### PR TITLE
Don't return 500s for books containing non-ASCII fields.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 You will need to have [Postgres](https://www.postgresql.org/) installed to run test and development databases.
 
-Once Postgres is install, you should have access to the `psql` command.
+Once Postgres is installed, you should have access to the `psql` command.
 
 ### Initialize database
 

--- a/Test_Runner_Story.postman_collection.json
+++ b/Test_Runner_Story.postman_collection.json
@@ -890,7 +890,7 @@
 		},
 		{
 			"key": "testBookAuthor",
-			"value": "bar",
+			"value": "פלוני אלמוני",
 			"type": "string"
 		},
 		{

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -36,7 +36,11 @@ export const filterObjStringsForProfanity = <T extends { [key: string]: any }>(
   Object.entries(obj).forEach(([k, v]) => {
     filtered[k] = v
     if (typeof v === 'string') {
-      filtered[k] = filterProfanity(v)
+      try {
+        filtered[k] = filterProfanity(v)
+      } catch (err) {
+        console.error(`Couldn't check ${v} for profanity.`);
+      };
     }
   })
   return filtered as T


### PR DESCRIPTION
Previously, trying to run e.g.:

    http --json :4000/books title=שלום genre=bar author=baz yearPublished=2023 api-key:postmanrulz

i.e. POST to /books with:

```json
{
    "title": "שלום",
    "genre": "bar",
    "author": "baz",
    "yearPublished": 2023
}
```

would blow up with:

```
HTTP/1.1 500 Internal Server Error
Connection: keep-alive
Date: Wed, 07 Jun 2023 16:24:11 GMT
Keep-Alive: timeout=5
content-length: 107
content-type: application/json; charset=utf-8

{
    "error": "Internal Server Error",
    "message": "Cannot read properties of null (reading '0')",
    "statusCode": 500
}
```

This error actually comes from the bad-words library during profanity
filtering, so it can actually be minimized to:

```
> var Filter = require('bad-words'),
...     filter = new Filter();
> filter.clean("שלום עליכם");
Uncaught TypeError: Cannot read properties of null (reading '0')
    at Filter.clean (/Users/julian/Development/library-api-v2/node_modules/.pnpm/bad-words@3.0.4/node_modules/bad-words/lib/badwords.js:58:41)

```

or even purely with JS regexes to:

```
/\b/.exec("שלום עליכם")
```

which just returns `null` because `\b` in JS doesn't cope with non-ASCII
word boundaries.

It seems slightly unlikely that `bad-words` would want some sort of
patch for this given it seems to only handle English anyhow (though
might file an issue anyhow in case it feels like at least doing nothing
in this case rather than blowing up).

But here, this patch makes us do the former, i.e. let through any
non-ASCII characters.

The test collection is also updated to make one of the fields actually
trigger this code path.
